### PR TITLE
Add DOMPurify to sanitize HTML

### DIFF
--- a/src/components/Article.js
+++ b/src/components/Article.js
@@ -29,9 +29,6 @@ export default class Article extends React.Component {
         let { urlToImage } = this.props.article;
         let articleImage = urlToImage;
 
-        title = '<p>Greeting: &quot;Hello, World!&quot;</p>';
-        description = '<p>Greeting: &quot;Hello, Description!&quot;</p>'
-
         title = DOMPurify.sanitize(title);
         description = DOMPurify.sanitize(description);
 


### PR DESCRIPTION
Added DOMPurify to sanitize HTML that are coming through the API.
This not only renders any HTML elements in the title and description of the article cards with dangerouslySetInnerHTML, but reduces security risk of the extension