### PR TITLE
Fix font size in typography.scss

### DIFF
--- a/src/styles/base/_typography.scss
+++ b/src/styles/base/_typography.scss
@@ -19,7 +19,7 @@ h1 {
 
 h2 {
     font-family: -apple-system, "Inter UI", sans-serif;
-    font-size: 2.4px;
+    font-size: 2.4rem;
     font-weight: 700;
     line-height: 1.20;
     margin-top: 3.0rem;
@@ -43,7 +43,7 @@ h3 {
 
 p {
     font-family: -apple-system, "Inter UI", sans-serif;
-    font-size: 16px;
+    font-size: 1.6rem;
     font-weight: 400;
     line-height: 1.60;
     margin-top: 0;


### PR DESCRIPTION
Some font sizing was outdated and not updated to work with the 
`font-size: 62.5%;` in the base.scss file