### PR TITLE
Removes author from article footer

### DIFF
--- a/src/components/Articles/Article/Article.js
+++ b/src/components/Articles/Article/Article.js
@@ -125,7 +125,7 @@ export const Article = ({
       <Footer>
         <p>
           {startCase(published)}{" "}
-          {!author || author.length > 15 ? null : ` — ${author}`}
+          {/* {!author || author.length > 15 ? null : ` — ${author}`} */}
         </p>
         <Bookmark checked={checked} onClick={(e) => onHandleBookmark(e)}>
           {checked ? <BsBookmarkFill /> : <BsBookmark />}


### PR DESCRIPTION
Displaying the author creates inconsistencies in card UI, and I'm unsure how important it is to show from a user's standpoint.

Before: 
![image](https://user-images.githubusercontent.com/10606336/86264364-6a389800-bb90-11ea-8fac-8e3ad6b13fd8.png)


After:
![image](https://user-images.githubusercontent.com/10606336/86264331-5b51e580-bb90-11ea-9468-4129d10b1c72.png)
